### PR TITLE
feat: register ferry, trawler, horizon as first-class ShipTypes + pipeline verification

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,7 +1,7 @@
 # harborglow — Weekly Plan
 
 ## Today's focus
-**2026-04-26 — User Idea mode.** Expand the procedural ship blueprint set with three new vessels: a passenger ferry, a fishing trawler, and a research vessel. The blueprint pipeline (ships.json + ShipBlueprint.ts + ProceduralShip.tsx) is clean and well-understood; only 3 ships exist against a system designed for variety. More blueprints stress-test upgrade-point generation, per-ship music mapping, and the living-fleet departure/return cycle simultaneously.
+**2026-05-03 — User Idea mode.** Wire `SequencerSystem` into the upgrade completion cinematic: replace the two raw `setTimeout` calls in `LyricsDisplay.tsx` and any remaining wall-clock timing in the cinematic path with `sequencerSystem.schedule()` calls locked to the Tone.js Transport. Introduce a single `triggerUpgradeCinematic(shipType)` entry point in `musicSystem.ts` (or a thin `cinematicSystem.ts`) that sequences spotlight hit → lyric reveal → camera cut as explicit Transport-offset cues, then wire that call into `MainScene.tsx` at both the crane upgrade-complete and tugboat win paths.
 
 ## Ideas
 <!--
@@ -10,8 +10,7 @@ Routine prioritizes these over generated ideas.
 Format: - [ ] Short description (optional: more context on next line indented)
 Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 -->
-- [in progress — 2026-04-26] Expand procedural ship blueprint set: ferry, fishing trawler, research vessel (half-to-full day). Blueprints pipeline exists but only 3 ships; more variety stresses upgrade-point generation and music-per-ship mapping.
-- [ ] Music/event sync timeline: explicit sequencer wiring Tone.js Transport to cinematic triggers (spotlight hits, lyric reveals, camera cuts). Would replace ad-hoc setTimeouts in `audioVisualSync.ts` and friends. Multi-day.
+- [in progress — 2026-05-03] Music/event sync timeline: explicit sequencer wiring Tone.js Transport to cinematic triggers (spotlight hits, lyric reveals, camera cuts). Would replace ad-hoc setTimeouts in `audioVisualSync.ts` and friends. Multi-day.
 
 ## Backlog
 <!--
@@ -23,6 +22,8 @@ Routine maintains this automatically — you can add items too.
 - [ ] 4 circular-dep warnings: `harborEventSystem` reexport through `eventSystem/index.ts` affects OnDockRail, DistantShipQueue, techSystem, MainScene — resolve the barrel-export cycle.
 - [ ] No test runner wired in package.json — vitest setup is a future hygiene task.
 - [ ] deploy.py: password hardcoded in plaintext (line 45); recursive call uses outer `sftp` var — fix before any real deploy.
+- [ ] introMusicSystem awaits AI-generated MP3 assets (`./audio/clear_harbor_glow_intro.mp3`, `./audio/clear_harbor_glow_loop.mp3`) — procedural fallback active; MiniMax generation pending (lyrics + production notes in `intro_song.md`).
+- [ ] God-rays WGSL compute shader staged at `shaders/god-rays-compute.wgsl` — not wired into PostProcessing pipeline; future WebGPU integration task.
 
 ## Research notes — multiview camera dashboard (2026-04-19)
 Architecture decision locked after running C-prompts:
@@ -43,6 +44,9 @@ Architecture decision locked after running C-prompts:
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- 2026-05-03 — Ship blueprints: Island Hopper ferry, North Star trawler, Horizon Deep research vessel added to `ships.json` (ea1390e; kimi-cli swarm, 3 iterations, build PASS).
+- 2026-05-03 — `sequencerSystem.ts` skeleton (143 LOC): Transport-locked scheduler with `schedule` / `scheduleAt` / `seekTo` / `cancel` / `clearAll`. `musicSystem.triggerClimax` now uses `transport.scheduleOnce`. `audioVisualSync` Transport-state guard added (d612c5b, Copilot).
+- 2026-05-03 — `introMusicSystem.ts` + `introLyrics.ts`: title anthem system with MiniMax MP3 detection + procedural fallback, wired into `MainMenu` + `App` screen transitions (f214de0).
 - 2026-04-26 — HEARTBEAT.md refreshed (PR #10 pipeline hygiene pass; HEARTBEAT now shows Apr 19 2026, 0 TODOs).
 - 2026-04-26 — TODO/FIXME count confirmed at 0 (crane interactivity stub resolved in physics tuning work).
 - 2026-04-19 — Crane-to-ship attachment tuning: 150ms bind-interpolation, delta-corrected sway decay, framerate-independent damping, twistlock cable lockout (PR #8 area).
@@ -53,7 +57,7 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-04-26
+Date: 2026-05-03
 Mode: User Idea
-Focus: Expand procedural ship blueprint set — passenger ferry, fishing trawler, research vessel added to ships.json
+Focus: Music/event sync timeline — wire SequencerSystem into upgrade completion cinematic (spotlight hit → lyric reveal → camera cut via Transport-locked sequencer)
 Outcome: (fill in at end of day)


### PR DESCRIPTION
## Summary

- Register `'ferry' | 'trawler' | 'horizon'` in the `ShipType` union — these ships had blueprints in `ships.json` but were unspawnable via the typed API
- Propagate to all 16 `Record<ShipType, ...>` maps across the codebase (full list in commit message)
- Add complete music entries for all three new ships (band names, lyrics, synths, transports)
- Fix `DistantShipQueue.tsx` dimensions switch exhaustiveness (was silently returning `undefined` for new types at runtime)
- `npm run build` passes clean, 0 TypeScript errors, 0 TODOs/FIXMEs

## Changes

### Core type
- `src/store/useGameStore.ts` — ShipType union + upgradeCounts

### Music (new tracks)
- `src/systems/musicSystem.ts` — Island Crossings (reggae/115 BPM), Saltwater Crew (sea shanty/95 BPM), Deep Meridian (oceanic ambient/100 BPM)

### Ship spawning
- `src/systems/shipSpawner.ts` — name pools, lengths, getShipTypeInfo

### Visual/UI records
- `src/components/DesignSystem.ts`, `upgradeConfigs.ts`, `ShipSpawner.tsx`, `hud/ShipStatusPanel.tsx`, `hud/TopBar.tsx`
- `src/scenes/Ship.tsx`, `MainScene.tsx`, `AudioReactiveLightShow.tsx`, `DistantShipQueue.tsx`
- `src/systems/attachmentSystem.ts`, `techSystem.ts`, `trafficSystem.ts`

## Pipeline verification results (Step E)
1. **Heartbeat**: PASS — build clean, 0 TODOs/FIXMEs
2. **ShipType vs musicSystem**: 3 gaps found and fixed (ferry, trawler, horizon had no synths/transports)
3. **ProceduralShip**: No missing branches — generic blueprint path handles all types correctly
4. **sequencerSystem singleton**: Instantiated exactly once in `sequencerSystem.ts`; not imported anywhere else yet (wiring is today's kimi-cli task)

https://claude.ai/code/session_01HghhE7wKw8kzYS2zBaNnyB