### PR TITLE
fix: resolve Tone.js timing error and WebGL useProgram invalid-op

### DIFF
--- a/src/components/InstallationFeedback.tsx
+++ b/src/components/InstallationFeedback.tsx
@@ -29,8 +29,8 @@ const playInstallSound = async (rigType: RigType) => {
     octaves: 1.5
   }).toDestination()
   
-  // Play satisfying mechanical lock sound
-  const now = Tone.now()
+  // Small lookahead buffer — avoids scheduling at an already-past AudioContext time
+  const now = Tone.now() + 0.05
   
   // Chord based on rig type
   const chords: Record<RigType, string[]> = {

--- a/src/components/VisualFeedback.tsx
+++ b/src/components/VisualFeedback.tsx
@@ -306,8 +306,8 @@ export function useUpgradeSounds() {
       const synth = new Tone.PolySynth(Tone.Synth).toDestination()
       synth.volume.value = -10
       
-      // Play a pleasant chord
-      synth.triggerAttackRelease(['C5', 'E5', 'G5'], '8n')
+      // Play a pleasant chord — schedule slightly ahead to avoid past-time errors
+      synth.triggerAttackRelease(['C5', 'E5', 'G5'], '8n', Tone.now() + 0.05)
       
       // Add a sparkle effect
       const sparkle = new Tone.MetalSynth({
@@ -329,8 +329,8 @@ export function useUpgradeSounds() {
       const synth = new Tone.PolySynth(Tone.Synth).toDestination()
       synth.volume.value = -5
       
-      // Fanfare
-      const now = Tone.now()
+      // Fanfare — lookahead buffer so bass (created below) isn't scheduled in the past
+      const now = Tone.now() + 0.05
       synth.triggerAttackRelease('C4', '8n', now)
       synth.triggerAttackRelease('E4', '8n', now + 0.1)
       synth.triggerAttackRelease('G4', '8n', now + 0.2)

--- a/src/scenes/GlobalIllumination.tsx
+++ b/src/scenes/GlobalIllumination.tsx
@@ -49,96 +49,35 @@ function padColor(arr: THREE.Color[], size: number): THREE.Color[] {
 //   sampleCount: 4
 // }
 
-// SSGI shader functions
+// Hash helper used by irradiance sampling
 const ssgiFunctions = `
-  // Hash function for random sampling
   float hash(vec2 p) {
     return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
   }
-  
-  // Screen-space ray marching for bounce lighting
-  vec3 ssgiTrace(vec3 worldPos, vec3 worldNormal, vec3 viewDir, sampler2D depthTexture, sampler2D colorTexture, mat4 projectionMatrix, mat4 viewMatrix, vec2 resolution) {
-    vec3 accumulatedLight = vec3(0.0);
-    float totalWeight = 0.0;
-    
-    // Sample directions in hemisphere
-    for (int i = 0; i < 4; i++) {
-      // Generate random direction in hemisphere
-      float angle = hash(worldPos.xy + vec2(float(i), uTime)) * 6.28318;
-      float radius = hash(worldPos.yz + vec2(float(i), uTime * 0.5));
-      
-      vec3 sampleDir = normalize(vec3(
-        cos(angle) * radius,
-        sin(angle) * radius,
-        sqrt(1.0 - radius * radius)
-      ));
-      
-      // Transform to world space
-      vec3 tangent = normalize(cross(worldNormal, vec3(0.0, 1.0, 0.0)));
-      if (length(tangent) < 0.001) tangent = normalize(cross(worldNormal, vec3(1.0, 0.0, 0.0)));
-      vec3 bitangent = cross(worldNormal, tangent);
-      
-      sampleDir = tangent * sampleDir.x + bitangent * sampleDir.y + worldNormal * sampleDir.z;
-      
-      // Ray march in screen space
-      vec3 rayPos = worldPos + sampleDir * 0.1;
-      float stepSize = 0.5;
-      
-      for (int step = 0; step < 32; step++) {
-        rayPos += sampleDir * stepSize;
-        
-        // Project to screen space
-        vec4 clipPos = projectionMatrix * viewMatrix * vec4(rayPos, 1.0);
-        vec2 screenPos = clipPos.xy / clipPos.w * 0.5 + 0.5;
-        
-        // Check bounds
-        if (screenPos.x < 0.0 || screenPos.x > 1.0 || screenPos.y < 0.0 || screenPos.y > 1.0) break;
-        
-        // Sample depth
-        float sceneDepth = texture2D(depthTexture, screenPos).r;
-        float rayDepth = clipPos.w;
-        
-        // Hit detection
-        if (rayDepth > sceneDepth * 1.1) {
-          // We hit something, accumulate color
-          vec3 hitColor = texture2D(colorTexture, screenPos).rgb;
-          float weight = max(0.0, dot(sampleDir, worldNormal));
-          accumulatedLight += hitColor * weight;
-          totalWeight += weight;
-          break;
-        }
-        
-        stepSize *= 1.1; // Exponential step size
-      }
-    }
-    
-    return totalWeight > 0.0 ? accumulatedLight / totalWeight * 0.3 : vec3(0.0);
-  }
 `
 
-// Irradiance sampling function
+// Irradiance sampling function — loop uses compile-time constant bound (GLSL ES 1.0 safe)
 const irradianceFunctions = `
-  // Sample irradiance from probe grid
   vec3 sampleIrradiance(vec3 worldPos, vec3 normal) {
     vec3 irradiance = vec3(0.0);
     float totalWeight = 0.0;
-    
-    // Sample nearby probes (simplified - would use actual probe grid)
-    for (int i = 0; i < uNumProbes; i++) {
+
+    for (int i = 0; i < ${MAX_PROBES}; i++) {
+      if (i >= uNumProbes) break;
       vec3 probePos = uProbePositions[i];
       vec3 probeIrradiance = uProbeIrradiance[i];
       float probeRadius = uProbeRadii[i];
-      
+
       float dist = length(worldPos - probePos);
       if (dist > probeRadius) continue;
-      
+
       float weight = 1.0 - dist / probeRadius;
       weight *= max(0.0, dot(normal, normalize(probePos - worldPos)));
-      
+
       irradiance += probeIrradiance * weight;
       totalWeight += weight;
     }
-    
+
     return totalWeight > 0.0 ? irradiance / totalWeight : vec3(0.0);
   }
 `

--- a/src/systems/musicSystem.ts
+++ b/src/systems/musicSystem.ts
@@ -589,8 +589,8 @@ class MusicSystem {
         const [containerFm, membrane, metal] = containerSynths
 
         // Techno beat
-        const kickPart = new Tone.Sequence(() => {
-            membrane?.triggerAttackRelease('C1', '8n')
+        const kickPart = new Tone.Sequence((time) => {
+            membrane?.triggerAttackRelease('C1', '8n', time)
         }, ['C1', null, 'C1', null, 'C1', null, 'C1', null])
         kickPart.loop = true
 
@@ -697,8 +697,8 @@ class MusicSystem {
         roroBassPart.loop = true
 
         // Driving beat
-        const roroBeatPart = new Tone.Sequence(() => {
-            roroDrum?.triggerAttackRelease('C1', '8n')
+        const roroBeatPart = new Tone.Sequence((time) => {
+            roroDrum?.triggerAttackRelease('C1', '8n', time)
         }, ['C1', 'C1', null, 'C1', null, 'C1', 'C1', null])
         roroBeatPart.loop = true
 


### PR DESCRIPTION
Tone.js 'Start time must be strictly greater than previous start time':
- musicSystem: kickPart and roroBeatPart Sequence callbacks were missing the `time` arg; triggerAttackRelease fell back to Tone.now() inside an already-advanced Transport tick, scheduling into the past.
- InstallationFeedback/VisualFeedback: `now` captured before synth construction; added +0.05s lookahead so bass/sparkle synths created after the timestamp are never scheduled in the past.

WebGL INVALID_OPERATION useProgram program not valid:
- GlobalIllumination: removed dead ssgiTrace() GLSL function (never called from main(), took sampler2D as parameters — invalid in GLSL ES 1.0).
- GlobalIllumination: irradianceFunctions loop bound changed from uniform `uNumProbes` to compile-time constant `MAX_PROBES` (32) with a dynamic break, making it valid across both GLSL ES 1.0 and 3.0.

https://claude.ai/code/session_01J5vMeLVKkERtCPBJfgCGH4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced audio timing precision for sound effects and music playback to prevent scheduling delays
- Optimized global illumination shader for improved rendering performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/harborglow/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->