### PR TITLE
fix: resolve WebGL useProgram errors on load (GLSL shader bugs)

### DIFF
--- a/src/scenes/Water.tsx
+++ b/src/scenes/Water.tsx
@@ -243,7 +243,6 @@ export default function Water({ isNight = true }: WaterProps) {
       vec3 halfDir = normalize(uSunDir + viewDir);
       float NdotH = max(dot(normal, halfDir), 0.0);
       // GGX-like distribution simplified
-      float alpha = uRoughness * uRoughness;
       float specular = pow(NdotH, 128.0 * (1.0 - uRoughness));
       specular *= (1.0 + uStormIntensity * 0.3); // storm boosts sparkle
 


### PR DESCRIPTION
## Summary

- **GlobalIllumination.tsx** (commit `3d84d83`): Removed dead `ssgiTrace()` function that used `sampler2D` as function parameters (GLSL ES 1.0 invalid); fixed `irradianceFunctions` loop to use compile-time constant `${MAX_PROBES}` instead of uniform `uNumProbes` as loop bound (GLSL ES 1.0 requires constant loop bounds)
- **Water.tsx** (commit `b638d29`): Removed duplicate `float alpha` declaration — the variable was declared twice in the same `main()` scope (once as a dead roughness scratch value, once as the actual transparency output), causing GLSL link failure
- **musicSystem.ts / InstallationFeedback.tsx / VisualFeedback.tsx** (commit `3d84d83`): Fixed Tone.js "Start time must be strictly greater than previous start time" errors by forwarding Transport `time` parameter in Sequence callbacks and adding `+0.05` lookahead buffers to `Tone.now()` calls

## Root causes

All `WebGL: INVALID_OPERATION: useProgram: program not valid` errors on load were GLSL ES 1.0 incompatibilities — Three.js `ShaderMaterial` defaults to GLSL ES 1.00 even in a WebGL 2 context:
- `sampler2D` as function parameters → invalid in GLSL ES 1.00
- Dynamic uniform as `for` loop bound → requires compile-time constant
- Variable redeclaration in same scope → invalid in all GLSL versions

## Test plan

- [ ] Load game — no `useProgram: program not valid` errors in console
- [ ] Water surface renders and animates correctly
- [ ] Global illumination overlay renders (additive blend over scene)
- [ ] Install a light rig — no Tone.js timing errors
- [ ] Music plays without "Start time" console errors

https://claude.ai/code/session_01J5vMeLVKkERtCPBJfgCGH4

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5vMeLVKkERtCPBJfgCGH4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized water shader's specular reflection calculations to streamline rendering while preserving storm effects and surface sparkle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/harborglow/pull/25)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->