### PR TITLE
Fix React Rules-of-Hooks crash in UpgradeMenu / useCompletionGlow

### DIFF
--- a/src/components/UpgradeMenu.tsx
+++ b/src/components/UpgradeMenu.tsx
@@ -216,23 +216,15 @@ export default function UpgradeMenu() {
         }
     }, [currentShipId, setHighlightedUpgradePart])
 
-    if (!currentShip) {
-        return (
-            <div style={menuContainerStyle}>
-                <h3 style={{ margin: '0 0 10px 0', color: '#aaa' }}>No Ship Selected</h3>
-                <p style={{ color: '#888', fontSize: '12px' }}>
-                    Spawn a ship using the buttons above
-                </p>
-            </div>
-        )
-    }
-
-    const upgradeOptions = UPGRADE_CONFIGS[currentShip.type]
-    const shipUpgrades = installedUpgrades.filter(u => u.shipId === currentShip.id)
+    // Hooks must run unconditionally on every render — compute null-safe
+    // derived values here so the "no ship selected" branch below stays a
+    // pure render-time early return, not an early-return-before-hooks.
+    const upgradeOptions = currentShip ? UPGRADE_CONFIGS[currentShip.type] : []
+    const shipUpgrades = currentShip ? installedUpgrades.filter(u => u.shipId === currentShip.id) : []
     const installedPartNames = new Set(shipUpgrades.map(u => u.partName))
     const availableUpgrades = upgradeOptions.filter(opt => !installedPartNames.has(opt.partName))
-    const progress = (shipUpgrades.length / upgradeOptions.length) * 100
-    const shipColor = shipTypeColors[currentShip.type]
+    const progress = upgradeOptions.length > 0 ? (shipUpgrades.length / upgradeOptions.length) * 100 : 0
+    const shipColor = currentShip ? shipTypeColors[currentShip.type] : '#4a6fa5'
     const queueableUpgrades = availableUpgrades.filter(opt => selectedForQueue.has(opt.partName))
 
     useEffect(() => {
@@ -283,6 +275,19 @@ export default function UpgradeMenu() {
             .filter((point): point is { x: number; y: number } => Boolean(point))
     }, [cranePosition.x, cranePosition.y, cranePosition.z, currentShip, queueableUpgrades])
 
+    const glow = useCompletionGlow()
+
+    if (!currentShip) {
+        return (
+            <div style={menuContainerStyle}>
+                <h3 style={{ margin: '0 0 10px 0', color: '#aaa' }}>No Ship Selected</h3>
+                <p style={{ color: '#888', fontSize: '12px' }}>
+                    Spawn a ship using the buttons above
+                </p>
+            </div>
+        )
+    }
+
     const handleSelectUpgrade = (partName: string) => {
         // If already navigating to this one, do nothing
         if (pendingAutoInstall?.partName === partName) return
@@ -331,8 +336,6 @@ export default function UpgradeMenu() {
             setIsUpgradingVersion(false)
         }
     }
-
-    const glow = useCompletionGlow()
 
     const currentVersion = currentShip?.version || '1.0'
     const versionMap: Record<string, string> = { '1.0': '1.5', '1.5': '2.0', '2.0': '2.0' }

--- a/src/hooks/useCompletionGlow.ts
+++ b/src/hooks/useCompletionGlow.ts
@@ -19,11 +19,14 @@ export function useCompletionGlow(): CompletionGlowStyle | null {
     : false
   const isMusicPlaying = currentShip ? musicPlaying.get(currentShip.id) === true : false
 
+  // useMusicPulse must run unconditionally on every render (Rules of Hooks);
+  // the glow style itself is what we gate on the completion state.
+  const pulse = useMusicPulse(bpm)
+
   if (!currentShip || !isFullyUpgraded || !isMusicPlaying) {
     return null
   }
 
-  const pulse = useMusicPulse(bpm)
   const pulseBoost = pulse > 0.3 ? 1 + pulse * 0.8 : 1
 
   return {


### PR DESCRIPTION
## Summary

`npm run lint` was reporting 4 `react-hooks/rules-of-hooks` errors that turn out to be a real, reproducible crash:

- `UpgradeMenu.tsx` called `useEffect`, `useMemo`, and `useCompletionGlow()` **after** its `if (!currentShip) { return <NoShipSelected/> }` early return.
- `useCompletionGlow.ts` called `useMusicPulse(bpm)` **after** its own `if (!currentShip || !isFullyUpgraded || !isMusicPlaying) return null` early return.

Both throw `Rendered more hooks than during the previous render` the instant the gated branch flips — which happens on **every single session**, the moment the player selects their first ship (UpgradeMenu goes from "No Ship Selected" → full render). This crashes `<UpgradeMenu>` into the `ErrorBoundary` fallback.

## Fix

Moved the hook calls (and the derived values they depend on, made null-safe) to execute unconditionally before any early return, so hook order/count stays constant across renders. No behavioral changes — values are identical once `currentShip` exists.

## Verification

Reproduced live in the browser with Playwright:

**Before the fix** (stashed the diff): spawning ships and selecting the first one threw
```
Rendered more hooks than during the previous render.
Warning: React has detected a change in the order of Hooks called by UpgradeMenu...
ErrorBoundary caught error: Error: Rendered more hooks than during the previous render.
```
and the menu crashed to the error boundary.

**After the fix**: the exact same sequence (spawn cruise/container/tanker, cycle selection through all three) renders the full upgrade menu ("Upgrade Progress 0%", ship name, Structural Overhaul controls, etc.) with **zero** hook-order errors in the console.

Also confirmed:
- `npm run lint` → 0 errors (was 4), only pre-existing warnings remain
- `npx tsc --noEmit` → clean
- `npm test` → 95/95 passing

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 95 passed
- [x] Manual repro in browser: select first ship → no hook-order crash (was crashing before fix)
- [x] Cycled selection across cruise/container/tanker — stable, no errors

https://claude.ai/code/session_01WoZx639NxrUb9KAqvXePVq


---
_Generated by [Claude Code](https://claude.ai/code/session_01WoZx639NxrUb9KAqvXePVq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed React hooks compliance issues to ensure proper hook execution order and prevent potential rendering inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->